### PR TITLE
Convenience Sugar for .get

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,12 @@ Version.prototype.install = function (db, parent) {
       cb = options
       options = {}
     }
+    
+    if (cb && options && !(options instanceof Function) && typeof options !== "object") {
+      // option candy machine
+      options = {version: options}
+    }
+    
     if (options == null) options = {}
 
     if (options.version == null) {


### PR DESCRIPTION
This ought to simplify the .get API by wrapping non-objects into a version.

```
db.get("cpu", 1382630143599, new Function)
// will be transformed to
db.get("cpu", {version: 1382630143599}, new Function)
```
