### PR TITLE
unmakekey: convert buffer to string

### DIFF
--- a/util.js
+++ b/util.js
@@ -18,7 +18,7 @@ function makeKey(delimiter, key, version) {
 
 function unmakeKey(delimiter, key) {
   if (key == null) return {key: key}
-  var parts = key.split(delimiter)
+  var parts = key.toString().split(delimiter)
   // If this happens, who knows what's going on.
   if (parts.length <= 1) return {key: key}
 


### PR DESCRIPTION
In newer versions of level the given key is a buffer. This patch converts the key to a string before splitting it.